### PR TITLE
add woodpecker-pipeline package

### DIFF
--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -6,6 +6,20 @@
   "steps": [
     {
       "commands": [
+        "nix flake check"
+      ],
+      "image": "bash",
+      "name": "Nix flake check"
+    },
+    {
+      "commands": [
+        "nix flake show"
+      ],
+      "image": "bash",
+      "name": "Nix flake show"
+    },
+    {
+      "commands": [
         "attic login lounge-rocks https://cache.lounge.rocks $ATTIC_KEY --set-default"
       ],
       "image": "bash",
@@ -16,10 +30,20 @@
     },
     {
       "commands": [
-        "nix flake check"
+        "nix build '.#nixosConfigurations.CBPC-0123_LMH.config.system.build.toplevel' -o 'result-CBPC-0123_LMH'"
       ],
       "image": "bash",
-      "name": "Check flake"
+      "name": "Build CBPC-0123_LMH"
+    },
+    {
+      "commands": [
+        "attic push lounge-rocks:nix-cache 'result-CBPC-0123_LMH'"
+      ],
+      "image": "bash",
+      "name": "Push CBPC-0123_LMH to Attic",
+      "secrets": [
+        "attic_key"
+      ]
     },
     {
       "commands": [
@@ -34,23 +58,6 @@
       ],
       "image": "bash",
       "name": "Push nixos_portable to Attic",
-      "secrets": [
-        "attic_key"
-      ]
-    },
-    {
-      "commands": [
-        "nix build '.#nixosConfigurations.CBPC-0123_LMH.config.system.build.toplevel' -o 'result-cbpc-0123_lmh'"
-      ],
-      "image": "bash",
-      "name": "Build CBPC-0123_LMH"
-    },
-    {
-      "commands": [
-        "attic push lounge-rocks:nix-cache 'result-cbpc-0123_lmh'"
-      ],
-      "image": "bash",
-      "name": "Push CBPC-0123_LMH to Attic",
       "secrets": [
         "attic_key"
       ]

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         (import ./pkgs inputs) final prev;
 
       packages = forAllSystems (system: {
+        woodpecker-pipeline = nixpkgsFor.${system}.callPackage ./pkgs/woodpecker-pipeline { flake-self = self; inputs = inputs; };
         inherit (nixpkgsFor.${system}.lmh01)
           candy-icon-theme
           ;

--- a/pkgs/woodpecker-pipeline/default.nix
+++ b/pkgs/woodpecker-pipeline/default.nix
@@ -1,0 +1,66 @@
+# nix build .#woodpecker-pipeline && cat result| jq '.configs[].data' -r | jq > .woodpecker.yaml
+{ pkgs, flake-self, inputs }:
+with pkgs;
+writeText "pipeline" (builtins.toJSON {
+  configs =
+    let
+      # Map platform names between woodpecker and nix
+      woodpecker-platforms = {
+        "aarch64-linux" = "linux/arm64";
+        "x86_64-linux" = "linux/amd64";
+      };
+      nixFlakeCheck = {
+        name = "Nix flake check";
+        image = "bash";
+        commands = [ "nix flake check" ];
+      };
+      nixFlakeShow = {
+        name = "Nix flake show";
+        image = "bash";
+        commands = [ "nix flake show" ];
+      };
+      atticSetupStep = {
+        name = "Setup Attic";
+        image = "bash";
+        commands = [
+          "attic login lounge-rocks https://cache.lounge.rocks $ATTIC_KEY --set-default"
+        ];
+        secrets = [ "attic_key" ];
+      };
+    in
+    pkgs.lib.lists.flatten ([
+      (map
+        (arch: {
+          name = "Hosts with arch: ${arch}";
+          data = (builtins.toJSON {
+            labels.backend = "local";
+            # platform will be deprecated in the future!
+            platform = woodpecker-platforms."${arch}";
+            steps = pkgs.lib.lists.flatten
+              ([ nixFlakeCheck nixFlakeShow atticSetupStep ] ++ (map
+                (host:
+                  # only build hosts for the arch we are currently building
+                  if (flake-self.nixosConfigurations.${host}.pkgs.stdenv.hostPlatform.system
+                    != arch) then
+                    [ ]
+                  else [
+                    {
+                      name = "Build ${host}";
+                      image = "bash";
+                      commands = [
+                        "nix build '.#nixosConfigurations.${host}.config.system.build.toplevel' -o 'result-${host}'"
+                      ];
+                    }
+                    {
+                      name = "Push ${host} to Attic";
+                      image = "bash";
+                      commands =
+                        [ "attic push lounge-rocks:nix-cache 'result-${host}'" ];
+                      secrets = [ "attic_key" ];
+                    }
+                  ])
+                (builtins.attrNames flake-self.nixosConfigurations)));
+          });
+        }) [ "x86_64-linux" ])
+    ]);
+})


### PR DESCRIPTION
This package will be used for https://github.com/pinpox/woodpecker-flake-pipeliner in the future.

Currently is serves the purpose of auto generating the woodpecker yaml using `nix build .#woodpecker-pipeline && cat result| jq '.configs[].data' -r | jq > .woodpecker.yaml`.