### PR TITLE
add options module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
 
             modules = [
               (import "${./.}/machines/${x}/configuration.nix" { inherit self; })
+              self.nixosModules.options
             ];
 
           };

--- a/home-manager/modules/i3/default.nix
+++ b/home-manager/modules/i3/default.nix
@@ -20,7 +20,9 @@ in
       i3lock
       konsole
       playerctl # musik controlls for pipewire/pulse
-    ];
+    ]
+    ++ lib.optionals (config.lmh01.options.type == "desktop") [ ]
+    ++ lib.optionals (config.lmh01.options.type == "laptop") [ ];
 
     services = {
       dunst.enable = true; # notification daemon
@@ -53,7 +55,7 @@ in
 
         bars = [
           {
-            fonts = ["FontAwesome 11"];
+            fonts = [ "FontAwesome 11" ];
             position = "top";
             statusCommand = "${pkgs.i3status-rust}/bin/i3status-rs ~/.config/i3status-rust/config-top.toml";
           }
@@ -64,7 +66,7 @@ in
             # TODO Currently the wallpaper has to be copied to that location manually, 
             # it would be a good idea to create a package that sets the wallpaper automatically.
             # Then the image file could also be moved into that package
-            command = "${pkgs.feh}/bin/feh --bg-fill ~/.wallpaper.png .wallpaper.png"; 
+            command = "${pkgs.feh}/bin/feh --bg-fill ~/.wallpaper.png .wallpaper.png";
             always = false;
             notification = false;
           }

--- a/home-manager/profiles/common.nix
+++ b/home-manager/profiles/common.nix
@@ -1,7 +1,14 @@
 { lib, pkgs, flake-self, config, system-config, ... }:
 with lib;
 {
-  # This file contains stuff that should be setup the same on all my systems
+
+  options.lmh01.options = {
+    type = mkOption {
+      type = types.enum [ "desktop" "laptop" "server" ];
+      default = system-config.lmh01.options.type;
+      example = "server";
+    };
+  };
 
   imports = with flake-self.homeManagerModules; [
     git
@@ -9,6 +16,8 @@ with lib;
   ];
 
   config = {
+
+    # This file contains stuff that should be setup the same on all my systems
 
     # Packages to install on all systems
     home.packages = with pkgs; [
@@ -19,7 +28,7 @@ with lib;
       tree
       unzip
     ] ++ lib.optionals (system-config.nixpkgs.hostPlatform.system == "x86_64-linux") [ ];
-    
+
     # Programs to install on all systems
     programs = {
       starship.enable = true;
@@ -27,9 +36,7 @@ with lib;
     };
 
     # Services to start on all systems
-    services = {
-
-    };
+    services = { };
 
     # Home-manager nixpkgs config
     nixpkgs = {

--- a/modules/options/default.nix
+++ b/modules/options/default.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let cfg = config.lmh01.options;
+in
+{
+
+  options.lmh01.options = {
+
+    CISkip = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Wheter this host should be skipped by the CI pipeline";
+    };
+  };
+
+}

--- a/modules/options/default.nix
+++ b/modules/options/default.nix
@@ -12,6 +12,13 @@ in
       example = true;
       description = "Wheter this host should be skipped by the CI pipeline";
     };
+
+    type = mkOption {
+      type = types.enum [ "desktop" "laptop" "server" ];
+      default = "desktop";
+      example = "server";
+    };
+
   };
 
 }

--- a/pkgs/woodpecker-pipeline/default.nix
+++ b/pkgs/woodpecker-pipeline/default.nix
@@ -43,6 +43,10 @@ writeText "pipeline" (builtins.toJSON {
                   if (flake-self.nixosConfigurations.${host}.pkgs.stdenv.hostPlatform.system
                     != arch) then
                     [ ]
+                  else if
+                  # Skip hosts with this option set
+                    flake-self.nixosConfigurations.${host}.config.lmh01.options.CISkip then
+                    [ ]
                   else [
                     {
                       name = "Build ${host}";


### PR DESCRIPTION
* module is imported to all systems
* `CISkip` option disables woodpecker config for a single host (useful when a system is currently not in use)
* `type` allows laptop / desktop / server.