### PR TITLE
registry.nixpkgs.flake = nixpkgs;

### DIFF
--- a/machines/pi4b/configuration.nix
+++ b/machines/pi4b/configuration.nix
@@ -25,9 +25,6 @@
   sdImage.compressImage = false;
   sdImage.imageBaseName = "raspi-image";
 
-  nix.registry.nixpkgs.flake = nixpkgs;
-  nix.nixPath = [ "nixpkgs=${nixpkgs}" ];
-
   # this workaround is currently needed to build the sd-image
   # basically: there currently is an issue that prevents the sd-image to be built successfully
   # remove this once the issue is fixed!

--- a/modules/nix-common/default.nix
+++ b/modules/nix-common/default.nix
@@ -19,6 +19,9 @@
     # --list` should be empty for all users afterwards
     nixPath = [ "nixpkgs=${nixpkgs}" ];
 
+    # allow the use of `nix run nixpkgs#hello` instead of nix run 'github:nixos/nixpkgs#hello'
+    registry.nixpkgs.flake = nixpkgs;
+
     package = pkgs.nixVersions.stable;
 
     extraOptions = ''


### PR DESCRIPTION
This makes sense for all hosts!

It allows the use of `nix run nixpkgs#hello` instead of nix run 'github:nixos/nixpkgs#hello'